### PR TITLE
Fix default config file name in help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ mcphost -m openai:gpt-4
 ### Flags
 - `--anthropic-url string`: Base URL for Anthropic API (defaults to api.anthropic.com)
 - `--anthropic-api-key string`: Anthropic API key (can also be set via ANTHROPIC_API_KEY environment variable)
-- `--config string`: Config file location (default is $HOME/mcp.json)
+- `--config string`: Config file location (default is $HOME/.mcp.json)
 - `--debug`: Enable debug logging
 - `--message-window int`: Number of messages to keep in context (default: 10)
 - `-m, --model string`: Model to use (format: provider:model) (default "anthropic:claude-3-5-sonnet-latest")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,7 +72,7 @@ var debugMode bool
 
 func init() {
 	rootCmd.PersistentFlags().
-		StringVar(&configFile, "config", "", "config file (default is $HOME/mcp.json)")
+		StringVar(&configFile, "config", "", "config file (default is $HOME/.mcp.json)")
 	rootCmd.PersistentFlags().
 		IntVar(&messageWindow, "message-window", 10, "number of messages to keep in context")
 	rootCmd.PersistentFlags().


### PR DESCRIPTION
Hi. Thank you for a nice tool.
I found a little typo in help message.