### PR TITLE
Allow to connect to remote SSE MCP server

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -220,7 +220,7 @@ func updateRenderer() error {
 // Method implementations for simpleMessage
 func runPrompt(
 	provider llm.Provider,
-	mcpClients map[string]*mcpclient.StdioMCPClient,
+	mcpClients map[string]mcpclient.MCPClient,
 	tools []llm.Tool,
 	prompt string,
 	messages *[]history.HistoryMessage,


### PR DESCRIPTION
The change allows to connect to MCP SSE servers, not only to local STDIO servers.

The config should be like

```
{
  "mcpServers": {
    "data_storage": {
      "command": "sse_server",
      "args": [
          "http://your_host_name:8000/sse"
      ]
    }
  }
}
```

The command should be "sse_server". And the first argument is the SSE endpoint