### PR TITLE
Increase maximum length of prompt input

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -552,7 +552,8 @@ func runMCPHost(ctx context.Context) error {
 		var prompt string
 		err := huh.NewForm(huh.NewGroup(huh.NewText().
 			Title("Enter your prompt (Type /help for commands, Ctrl+C to quit)").
-			Value(&prompt)),
+			Value(&prompt).
+			CharLimit(5000)),
 		).WithWidth(getTerminalWidth()).
 			WithTheme(huh.ThemeCharm()).
 			Run()


### PR DESCRIPTION
Default maximum length is 400 characters.