### PR TITLE
Add ```omitempty``` to ```reasoning_content``` in OpenAI message API

### DIFF
--- a/pkg/llm/openai/types.go
+++ b/pkg/llm/openai/types.go
@@ -11,7 +11,7 @@ type CreateRequest struct {
 type MessageParam struct {
 	Role             string        `json:"role"`
 	Content          *string       `json:"content"`
-	ReasoningContent *string       `json:"reasoning_content"`
+	ReasoningContent *string       `json:"reasoning_content,omitempty"`
 	FunctionCall     *FunctionCall `json:"function_call,omitempty"`
 	ToolCalls        []ToolCall    `json:"tool_calls,omitempty"`
 	Name             string        `json:"name,omitempty"`


### PR DESCRIPTION
Add ```omitempty``` to ```reasoning_content``` in OpenAI message API. See issue [link](https://github.com/mark3labs/mcphost/issues/23).
Perhaps there are same issues in Ollama or any other API but I don't make those changes.