### PR TITLE
feat: support system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ go install github.com/mark3labs/mcphost@latest
 
 ## Configuration ⚙️
 
+### MCP-server
 MCPHost will automatically create a configuration file at `~/.mcp.json` if it doesn't exist. You can also specify a custom location using the `--config` flag:
 
 ```json
@@ -107,6 +108,23 @@ Each MCP server entry requires:
   - For SQLite server: `mcp-server-sqlite` with database path
   - For filesystem server: `@modelcontextprotocol/server-filesystem` with directory path
 
+
+### System-Prompt
+
+You can specify a custom system prompt using the `--system-prompt` flag. The system prompt should be a JSON file containing the instructions and context you want to provide to the model. For example:
+
+```json
+{
+    "systemPrompt": "You're a cat. Name is Neko"
+}
+```
+
+Usage:
+```bash
+mcphost --system-prompt ./my-system-prompt.json
+```
+
+
 ## Usage 🚀
 
 MCPHost is a CLI tool that allows you to interact with various AI models through a unified interface. It supports various tools through MCP servers.
@@ -136,6 +154,7 @@ mcphost --model openai:<your-model-name> \
 - `--anthropic-url string`: Base URL for Anthropic API (defaults to api.anthropic.com)
 - `--anthropic-api-key string`: Anthropic API key (can also be set via ANTHROPIC_API_KEY environment variable)
 - `--config string`: Config file location (default is $HOME/.mcp.json)
+- `--system-prompt string`: system-prompt file location
 - `--debug`: Enable debug logging
 - `--message-window int`: Number of messages to keep in context (default: 10)
 - `-m, --model string`: Model to use (format: provider:model) (default "anthropic:claude-3-5-sonnet-latest")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -151,7 +151,7 @@ func createProvider(ctx context.Context, modelString, systemPrompt string) (llm.
 			// The project structure is provider specific, but Google calls this GEMINI_API_KEY in e.g. AI Studio. Support both.
 			apiKey = os.Getenv("GEMINI_API_KEY")
 		}
-		return google.NewProvider(ctx, apiKey, model)
+		return google.NewProvider(ctx, apiKey, model, systemPrompt)
 
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", provider)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -612,7 +612,7 @@ func loadSystemPrompt(filePath string) (string, error) {
 		return "", fmt.Errorf("error reading config file: %v", err)
 	}
 
-	// Parse only the system_message field
+	// Parse only the systemPrompt field
 	var config struct {
 		SystemPrompt string `json:"systemPrompt"`
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,7 +124,7 @@ func createProvider(ctx context.Context, modelString, systemPrompt string) (llm.
 				"Anthropic API key not provided. Use --anthropic-api-key flag or ANTHROPIC_API_KEY environment variable",
 			)
 		}
-		return anthropic.NewProvider(apiKey, anthropicBaseURL, model), nil
+		return anthropic.NewProvider(apiKey, anthropicBaseURL, model, systemPrompt), nil
 
 	case "ollama":
 		return ollama.NewProvider(model, systemPrompt)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,7 @@ func init() {
 	rootCmd.PersistentFlags().
 		StringVar(&configFile, "config", "", "config file (default is $HOME/.mcp.json)")
 	rootCmd.PersistentFlags().
-		StringVar(&systemPrompt, "system-prompt", "", "system prompt")
+		StringVar(&systemPrompt, "system-prompt", "", "system prompt json file")
 	rootCmd.PersistentFlags().
 		IntVar(&messageWindow, "message-window", 10, "number of messages to keep in context")
 	rootCmd.PersistentFlags().

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ import (
 var (
 	renderer         *glamour.TermRenderer
 	configFile       string
-	systemPrompt     string
+	systemPromptFile string
 	messageWindow    int
 	modelFlag        string // New flag for model selection
 	openaiBaseURL    string // Base URL for OpenAI API
@@ -80,7 +80,7 @@ func init() {
 	rootCmd.PersistentFlags().
 		StringVar(&configFile, "config", "", "config file (default is $HOME/.mcp.json)")
 	rootCmd.PersistentFlags().
-		StringVar(&systemPrompt, "system-prompt", "", "system prompt json file")
+		StringVar(&systemPromptFile, "system-prompt", "", "system prompt json file")
 	rootCmd.PersistentFlags().
 		IntVar(&messageWindow, "message-window", 10, "number of messages to keep in context")
 	rootCmd.PersistentFlags().
@@ -477,7 +477,7 @@ func runMCPHost(ctx context.Context) error {
 		log.SetReportCaller(false)
 	}
 
-	systemPrompt, err := loadSystemPrompt(systemPrompt)
+	systemPrompt, err := loadSystemPrompt(systemPromptFile)
 	if err != nil {
 		return fmt.Errorf("error loading system prompt: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,7 +140,7 @@ func createProvider(ctx context.Context, modelString, systemPrompt string) (llm.
 				"OpenAI API key not provided. Use --openai-api-key flag or OPENAI_API_KEY environment variable",
 			)
 		}
-		return openai.NewProvider(apiKey, openaiBaseURL, model), nil
+		return openai.NewProvider(apiKey, openaiBaseURL, model, systemPrompt), nil
 
 	case "google":
 		apiKey := googleAPIKey

--- a/pkg/llm/anthropic/provider.go
+++ b/pkg/llm/anthropic/provider.go
@@ -12,17 +12,19 @@ import (
 )
 
 type Provider struct {
-	client *Client
-	model  string
+	client       *Client
+	model        string
+	systemPrompt string
 }
 
-func NewProvider(apiKey string, baseURL string, model string) *Provider {
+func NewProvider(apiKey, baseURL, model, systemPrompt string) *Provider {
 	if model == "" {
 		model = "claude-3-5-sonnet-20240620" // 默认模型
 	}
 	return &Provider{
-		client: NewClient(apiKey, baseURL),
-		model:  model,
+		client:       NewClient(apiKey, baseURL),
+		model:        model,
+		systemPrompt: systemPrompt,
 	}
 }
 
@@ -135,6 +137,7 @@ func (p *Provider) CreateMessage(
 		Messages:  anthropicMessages,
 		MaxTokens: 4096,
 		Tools:     anthropicTools,
+		System:    p.systemPrompt,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/llm/anthropic/types.go
+++ b/pkg/llm/anthropic/types.go
@@ -13,6 +13,7 @@ type CreateRequest struct {
 	Model     string         `json:"model"`
 	Messages  []MessageParam `json:"messages"`
 	MaxTokens int            `json:"max_tokens"`
+	System    string         `json:"system,omitempty"`
 	Tools     []Tool         `json:"tools,omitempty"`
 }
 

--- a/pkg/llm/google/provider.go
+++ b/pkg/llm/google/provider.go
@@ -25,7 +25,9 @@ func NewProvider(ctx context.Context, apiKey, model, systemPrompt string) (*Prov
 		return nil, err
 	}
 	m := client.GenerativeModel(model)
-	m.SystemInstruction = genai.NewUserContent(genai.Text(systemPrompt))
+	if systemPrompt != "" {
+		m.SystemInstruction = genai.NewUserContent(genai.Text(systemPrompt))
+	}
 	return &Provider{
 		client: client,
 		model:  m,

--- a/pkg/llm/google/provider.go
+++ b/pkg/llm/google/provider.go
@@ -25,6 +25,7 @@ func NewProvider(ctx context.Context, apiKey, model, systemPrompt string) (*Prov
 		return nil, err
 	}
 	m := client.GenerativeModel(model)
+	// If systemPrompt is provided, set the system prompt for the model.
 	if systemPrompt != "" {
 		m.SystemInstruction = genai.NewUserContent(genai.Text(systemPrompt))
 	}

--- a/pkg/llm/google/provider.go
+++ b/pkg/llm/google/provider.go
@@ -19,12 +19,13 @@ type Provider struct {
 	toolCallID int
 }
 
-func NewProvider(ctx context.Context, apiKey string, model string) (*Provider, error) {
+func NewProvider(ctx context.Context, apiKey, model, systemPrompt string) (*Provider, error) {
 	client, err := genai.NewClient(ctx, option.WithAPIKey(apiKey))
 	if err != nil {
 		return nil, err
 	}
 	m := client.GenerativeModel(model)
+	m.SystemInstruction = genai.NewUserContent(genai.Text(systemPrompt))
 	return &Provider{
 		client: client,
 		model:  m,

--- a/pkg/llm/openai/provider.go
+++ b/pkg/llm/openai/provider.go
@@ -12,8 +12,9 @@ import (
 )
 
 type Provider struct {
-	client *Client
-	model  string
+	client       *Client
+	model        string
+	systemPrompt string
 }
 
 func convertSchema(schema llm.Schema) map[string]interface{} {
@@ -30,10 +31,11 @@ func convertSchema(schema llm.Schema) map[string]interface{} {
 	}
 }
 
-func NewProvider(apiKey string, baseURL string, model string) *Provider {
+func NewProvider(apiKey, baseURL, model, systemPrompt string) *Provider {
 	return &Provider{
-		client: NewClient(apiKey, baseURL),
-		model:  model,
+		client:       NewClient(apiKey, baseURL),
+		model:        model,
+		systemPrompt: systemPrompt,
 	}
 }
 
@@ -49,6 +51,12 @@ func (p *Provider) CreateMessage(
 		"num_tools", len(tools))
 
 	openaiMessages := make([]MessageParam, 0, len(messages))
+	if p.systemPrompt != "" {
+		openaiMessages = append(openaiMessages, MessageParam{
+			Role:    "system",
+			Content: &p.systemPrompt,
+		})
+	}
 
 	// Convert previous messages
 	for _, msg := range messages {

--- a/pkg/llm/openai/provider.go
+++ b/pkg/llm/openai/provider.go
@@ -51,6 +51,8 @@ func (p *Provider) CreateMessage(
 		"num_tools", len(tools))
 
 	openaiMessages := make([]MessageParam, 0, len(messages))
+
+	// Add system prompt if provided
 	if p.systemPrompt != "" {
 		openaiMessages = append(openaiMessages, MessageParam{
 			Role:    "system",


### PR DESCRIPTION
It has been modified to support system prompts. 

### TEST
I tested it using below json
```json
{
    "systemPrompt": "You're a cat. Name is Neko"
}
```
![ollama-qwen](https://github.com/user-attachments/assets/1b503ee7-1b19-4f68-9309-a65471c5e5af)
![openai](https://github.com/user-attachments/assets/c14ac38f-bdfc-4a84-95c3-1482d30711ed)
![anthropic](https://github.com/user-attachments/assets/8166c6f3-6013-438e-aff1-a4b0106df7ae)
![google](https://github.com/user-attachments/assets/3e56dc40-a069-44fc-924f-95c4f9e94f25)

### Ref
- anthropic https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/system-prompts
- google gemini https://pkg.go.dev/github.com/google/generative-ai-go/genai#example-GenerativeModel.CountTokens-SystemInstruction
- openai https://platform.openai.com/docs/guides/prompt-generation
- ollama https://github.com/ollama/ollama/blob/main/docs/api.md