### PR TITLE
fix: Do not panic when reading malformed properties 

### DIFF
--- a/pkg/llm/google/provider.go
+++ b/pkg/llm/google/provider.go
@@ -125,7 +125,11 @@ func translateToGoogleSchema(schema llm.Schema) *genai.Schema {
 	}
 
 	for name, prop := range schema.Properties {
-		s.Properties[name] = propertyToGoogleSchema(prop.(map[string]any))
+		m, ok := prop.(map[string]any)
+		if !ok || len(m) == 0 {
+			continue
+		}
+		s.Properties[name] = propertyToGoogleSchema(m)
 	}
 
 	if len(s.Properties) == 0 {

--- a/pkg/llm/google/provider.go
+++ b/pkg/llm/google/provider.go
@@ -146,7 +146,11 @@ func translateToGoogleSchema(schema llm.Schema) *genai.Schema {
 }
 
 func propertyToGoogleSchema(properties map[string]any) *genai.Schema {
-	s := &genai.Schema{Type: toType(properties["type"].(string))}
+	typ, ok := properties["type"].(string)
+	if !ok {
+		return nil
+	}
+	s := &genai.Schema{Type: toType(typ)}
 	if desc, ok := properties["description"].(string); ok {
 		s.Description = desc
 	}


### PR DESCRIPTION
Background: I was trying to run the command:

* `mcphost -m google:gemini-2.5-pro`

with this `~/.mcp.json` file:

```json
{
  "mcpServers": {
    "desktop-commander": {
      "command": "npx",
      "args": [
        "-y",
        "@smithery/cli@latest",
        "run",
        "@wonderwhy-er/desktop-commander"
      ]
    }
  }
}
```

and set my GOOGLE_API_KEY appropriately.

`mcphost` started properly and the `/tools` and `/servers` commands worked fine.
However, when I typed in "How many ebooks are in my Downloads folder?" it would panic within the `propertyToGoogleSchema` method because when "name" was `"value"`, the resulting map was empty (although the `propertyToGoogleSchema` method assumes that the "type" key exists.

This PR fixes the panic on malformed `schema.Properties`.