### PR TITLE
Add number and integer types to google type converter

### DIFF
--- a/pkg/llm/google/provider.go
+++ b/pkg/llm/google/provider.go
@@ -166,6 +166,10 @@ func toType(typ string) genai.Type {
 	switch typ {
 	case "string":
 		return genai.TypeString
+	case "number":
+		return genai.TypeNumber
+	case "integer":
+		return genai.TypeInteger
 	case "boolean":
 		return genai.TypeBoolean
 	case "object":


### PR DESCRIPTION
The sample in mcp-go's [README](https://github.com/mark3labs/mcp-go/blob/main/README.md) fails because the `x` and `y` types aren't passed to the genai library. Adding number types resolves the issue.