### PR TITLE
Fix multiple requests at the same time

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -451,10 +451,12 @@ func runPrompt(
 	})
 
 	if len(toolResults) > 0 {
-		*messages = append(*messages, history.HistoryMessage{
-			Role:    "user",
-			Content: toolResults,
-		})
+		for _, toolResult := range toolResults {
+			*messages = append(*messages, history.HistoryMessage{
+				Role:    "tool",
+				Content: []history.ContentBlock{toolResult},
+			})
+		}
 		// Make another call to get Claude's response to the tool results
 		return runPrompt(ctx, provider, mcpClients, tools, "", messages)
 	}


### PR DESCRIPTION
Previously when multiple tool calls were requested by the LLM we got the error `An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'.` although the calls were processed.

Apparently each response needs to be its own message, rather than its own block.

Closes #7
