### PR TITLE
fix: crash when sending tool_result with anthropic and google

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -237,6 +237,15 @@ func updateRenderer() error {
 	return err
 }
 
+type llmProviderType int
+
+const (
+	llmProviderTypeAnthropic = iota
+	llmProviderTypeOllama
+	llmProviderTypeOpenAI
+	llmProviderTypeGoogle
+)
+
 // Method implementations for simpleMessage
 func runPrompt(
 	ctx context.Context,
@@ -245,6 +254,7 @@ func runPrompt(
 	tools []llm.Tool,
 	prompt string,
 	messages *[]history.HistoryMessage,
+	providerType llmProviderType,
 ) error {
 	// Display the user's prompt if it's not empty (i.e., not a tool response)
 	if prompt != "" {
@@ -455,13 +465,17 @@ func runPrompt(
 
 	if len(toolResults) > 0 {
 		for _, toolResult := range toolResults {
+			role := "tool"
+			if providerType == llmProviderTypeAnthropic {
+				role = "user"
+			}
 			*messages = append(*messages, history.HistoryMessage{
-				Role:    "tool",
+				Role:    role,
 				Content: []history.ContentBlock{toolResult},
 			})
 		}
 		// Make another call to get Claude's response to the tool results
-		return runPrompt(ctx, provider, mcpClients, tools, "", messages)
+		return runPrompt(ctx, provider, mcpClients, tools, "", messages, providerType)
 	}
 
 	fmt.Println() // Add spacing
@@ -488,6 +502,18 @@ func runMCPHost(ctx context.Context) error {
 	provider, err := createProvider(ctx, modelFlag, systemPrompt)
 	if err != nil {
 		return fmt.Errorf("error creating provider: %v", err)
+	}
+
+	var providerType llmProviderType
+	switch provider.(type) {
+	case *anthropic.Provider:
+		providerType = llmProviderTypeAnthropic
+	case *ollama.Provider:
+		providerType = llmProviderTypeOllama
+	case *openai.Provider:
+		providerType = llmProviderTypeOpenAI
+	case *google.Provider:
+		providerType = llmProviderTypeGoogle
 	}
 
 	// Split the model flag and get just the model name
@@ -596,7 +622,7 @@ func runMCPHost(ctx context.Context) error {
 		if len(messages) > 0 {
 			messages = pruneMessages(messages)
 		}
-		err = runPrompt(ctx, provider, mcpClients, allTools, prompt, &messages)
+		err = runPrompt(ctx, provider, mcpClients, allTools, prompt, &messages, providerType)
 		if err != nil {
 			return err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -464,11 +464,11 @@ func runPrompt(
 	})
 
 	if len(toolResults) > 0 {
+		role := "tool"
+		if providerType == llmProviderTypeAnthropic {
+			role = "user"
+		}
 		for _, toolResult := range toolResults {
-			role := "tool"
-			if providerType == llmProviderTypeAnthropic {
-				role = "user"
-			}
 			*messages = append(*messages, history.HistoryMessage{
 				Role:    role,
 				Content: []history.ContentBlock{toolResult},

--- a/pkg/llm/anthropic/provider.go
+++ b/pkg/llm/anthropic/provider.go
@@ -199,21 +199,17 @@ func (p *Provider) CreateToolResponse(
 const (
 	roleUser      = "user"
 	roleAssistant = "assistant"
-	roleSystem    = "system"
-	roleTool      = "tool"
 )
 
+var roleMap = map[string]string{
+	roleUser:      roleUser,
+	roleAssistant: roleAssistant,
+}
+
 func mappingRole(role string) string {
-	switch role {
-	case roleUser:
-		return roleUser
-	case roleAssistant:
-		return roleAssistant
-	case roleSystem:
-		return roleSystem
-	case roleTool:
-		return roleUser
-	default:
+	v, ok := roleMap[role]
+	if !ok {
 		return roleUser
 	}
+	return v
 }

--- a/pkg/llm/anthropic/provider.go
+++ b/pkg/llm/anthropic/provider.go
@@ -97,7 +97,7 @@ func (p *Provider) CreateMessage(
 		// Always append the message, even if content is empty
 		// This maintains conversation flow
 		anthropicMessages = append(anthropicMessages, MessageParam{
-			Role:    msg.GetRole(),
+			Role:    mappingRole(msg.GetRole()),
 			Content: content,
 		})
 	}
@@ -194,4 +194,26 @@ func (p *Provider) CreateToolResponse(
 	}
 
 	return msg, nil
+}
+
+const (
+	roleUser      = "user"
+	roleAssistant = "assistant"
+	roleSystem    = "system"
+	roleTool      = "tool"
+)
+
+func mappingRole(role string) string {
+	switch role {
+	case roleUser:
+		return roleUser
+	case roleAssistant:
+		return roleAssistant
+	case roleSystem:
+		return roleSystem
+	case roleTool:
+		return roleUser
+	default:
+		return roleUser
+	}
 }

--- a/pkg/llm/google/provider.go
+++ b/pkg/llm/google/provider.go
@@ -41,7 +41,7 @@ func (p *Provider) CreateMessage(ctx context.Context, prompt string, messages []
 	for _, msg := range messages {
 		for _, call := range msg.GetToolCalls() {
 			hist = append(hist, &genai.Content{
-				Role: msg.GetRole(),
+				Role: mappingRole(msg.GetRole()),
 				Parts: []genai.Part{
 					genai.FunctionCall{
 						Name: call.GetName(),
@@ -56,7 +56,7 @@ func (p *Provider) CreateMessage(ctx context.Context, prompt string, messages []
 				for _, block := range historyMsg.Content {
 					if block.Type == "tool_result" {
 						hist = append(hist, &genai.Content{
-							Role:  msg.GetRole(),
+							Role:  mappingRole(msg.GetRole()),
 							Parts: []genai.Part{genai.Text(block.Text)},
 						})
 					}
@@ -66,7 +66,7 @@ func (p *Provider) CreateMessage(ctx context.Context, prompt string, messages []
 
 		if text := strings.TrimSpace(msg.GetContent()); text != "" {
 			hist = append(hist, &genai.Content{
-				Role:  msg.GetRole(),
+				Role:  mappingRole(msg.GetRole()),
 				Parts: []genai.Part{genai.Text(text)},
 			})
 		}
@@ -190,5 +190,27 @@ func toType(typ string) genai.Type {
 		return genai.TypeArray
 	default:
 		return genai.TypeUnspecified
+	}
+}
+
+const (
+	roleUser      = "user"
+	roleAssistant = "assistant"
+	roleSystem    = "system"
+	roleTool      = "tool"
+)
+
+func mappingRole(role string) string {
+	switch role {
+	case roleUser:
+		return roleUser
+	case roleAssistant:
+		return roleAssistant
+	case roleSystem:
+		return roleSystem
+	case roleTool:
+		return roleUser
+	default:
+		return roleUser
 	}
 }

--- a/pkg/llm/google/provider.go
+++ b/pkg/llm/google/provider.go
@@ -194,23 +194,19 @@ func toType(typ string) genai.Type {
 }
 
 const (
-	roleUser      = "user"
-	roleAssistant = "assistant"
-	roleSystem    = "system"
-	roleTool      = "tool"
+	roleUser  = "user"
+	roleModel = "model"
 )
 
+var roleMap = map[string]string{
+	roleUser:  roleUser,
+	roleModel: roleModel,
+}
+
 func mappingRole(role string) string {
-	switch role {
-	case roleUser:
-		return roleUser
-	case roleAssistant:
-		return roleAssistant
-	case roleSystem:
-		return roleSystem
-	case roleTool:
-		return roleUser
-	default:
+	v, ok := roleMap[role]
+	if !ok {
 		return roleUser
 	}
+	return v
 }


### PR DESCRIPTION
v0.7.0 does not work properly when using the anthropic model or google model.
This is because the role must be `user` to send a content block containing a `tool_result` type in anthropic and google.

> Continue the conversation by sending a new message with the role of user, and a content block containing the tool_result type and the following information:

https://docs.anthropic.com/en/docs/tool-use.

Also, there are only `user` and `model` roles in gemini, and `tool` does not seem to exist.

> role string
Optional. The producer of the content. Must be either 'user' or 'model'.

[ai.google.dev/api/caching?authuser=5&hl=en#Content](https://ai.google.dev/api/caching?authuser=5&hl=en#Content)

Related: https://github.com/mark3labs/mcphost/pull/33

Close: #36

Thank you.

### In v0.7.0

#### anthropic

![image](https://github.com/user-attachments/assets/56c17880-7701-4c65-a918-3651041dd258)

```sh
2025/04/25 07:35:19 INFO Model loaded provider=anthropic model=claude-3-5-sonnet-latest
2025/04/25 07:35:19 INFO Initializing server... name=fetch
2025/04/25 07:35:20 INFO Initializing server... name=mcp-restaurant-order
2025/04/25 07:35:21 INFO Initializing server... name=server-brave-search
2025/04/25 07:35:21 INFO Server connected name=mcp-restaurant-order
2025/04/25 07:35:21 INFO Server connected name=server-brave-search
2025/04/25 07:35:21 INFO Server connected name=fetch
2025/04/25 07:35:21 INFO Tools loaded server=fetch count=1
2025/04/25 07:35:21 INFO Tools loaded server=mcp-restaurant-order count=2
2025/04/25 07:35:21 INFO Tools loaded server=server-brave-search count=2

  You: What does MCP stand for? using brave-serch.

  Assistant:


  I'll search for what MCP stands for using Brave web search.

2025/04/25 07:35:30 INFO 🔧 Using tool name=server-brave-search__brave_web_search
2025/04/25 07:35:30 INFO Usage statistics input_tokens=1384 output_tokens=84 total_tokens=1468
2025/04/25 07:35:32 INFO Shutting down MCP servers...
```

#### google

![image](https://github.com/user-attachments/assets/d2d6ccff-ebf3-4733-8d48-35186b658ceb)

```sh
2025/04/25 07:33:44 INFO Model loaded provider=Google model=gemini-2.0-flash
2025/04/25 07:33:44 INFO Initializing server... name=fetch
2025/04/25 07:33:46 INFO Initializing server... name=mcp-restaurant-order
2025/04/25 07:33:46 INFO Initializing server... name=server-brave-search
2025/04/25 07:33:46 INFO Server connected name=server-brave-search
2025/04/25 07:33:46 INFO Server connected name=fetch
2025/04/25 07:33:46 INFO Server connected name=mcp-restaurant-order
2025/04/25 07:33:46 INFO Tools loaded server=fetch count=1
2025/04/25 07:33:46 INFO Tools loaded server=mcp-restaurant-order count=2
2025/04/25 07:33:46 INFO Tools loaded server=server-brave-search count=2

  You: What does MCP stand for? using brave-serch.
2025/04/25 07:33:57 INFO 🔧 Using tool name=server-brave-search__brave_web_search
2025/04/25 07:33:59 INFO Shutting down MCP servers...
```

### After correction

#### anthropic

![image](https://github.com/user-attachments/assets/17f674ad-7ba5-4c5f-8db1-b4a114e79742)

```sh
2025/04/25 07:27:21 INFO Model loaded provider=anthropic model=claude-3-5-sonnet-latest
2025/04/25 07:27:21 INFO Initializing server... name=fetch
2025/04/25 07:27:22 INFO Initializing server... name=mcp-restaurant-order
2025/04/25 07:27:22 INFO Initializing server... name=server-brave-search
2025/04/25 07:27:23 INFO Server connected name=fetch
2025/04/25 07:27:23 INFO Server connected name=mcp-restaurant-order
2025/04/25 07:27:23 INFO Server connected name=server-brave-search
2025/04/25 07:27:23 INFO Tools loaded server=fetch count=1
2025/04/25 07:27:23 INFO Tools loaded server=mcp-restaurant-order count=2
2025/04/25 07:27:23 INFO Tools loaded server=server-brave-search count=2

  You: What does MCP stand for? using brave-serch.

  Assistant:


  I'll search to find out what MCP stands for using Brave's web search, since this could have multiple meanings depending on the context.

2025/04/25 07:27:28 INFO 🔧 Using tool name=server-brave-search__brave_web_search
2025/04/25 07:27:28 INFO Usage statistics input_tokens=1384 output_tokens=101 total_tokens=1485

  Assistant:


  Based on the search results, MCP can stand for several different things depending on the context:

  1. Model Context Protocol - A recent open standard designed by Anthropic to help AI assistants interact with data and tools
  2. Microsoft Certified Professional - A certification from Microsoft
  3. Microsoft Certified Partner - An independent company providing Microsoft-related products or services
  4. Male Chauvinist Pig (informal, derogatory)
  5. Master Control Program (in computing contexts)

  Given that you're asking this question in the context of the available tools which include "mcp-restaurant-order", it's most likely referring to "Model Context Protocol" which is the system
  that
  enables AI assistants to interact with external tools and services, like the restaurant ordering system we have access to.
```

#### google

![image](https://github.com/user-attachments/assets/21ccca43-63fd-4939-b223-72c741e733b7)

```sh
2025/04/25 07:27:42 INFO Model loaded provider=Google model=gemini-2.0-flash
2025/04/25 07:27:42 INFO Initializing server... name=server-brave-search
2025/04/25 07:27:42 INFO Initializing server... name=fetch
2025/04/25 07:27:43 INFO Initializing server... name=mcp-restaurant-order
2025/04/25 07:27:43 INFO Server connected name=server-brave-search
2025/04/25 07:27:43 INFO Server connected name=fetch
2025/04/25 07:27:43 INFO Server connected name=mcp-restaurant-order
2025/04/25 07:27:43 INFO Tools loaded server=server-brave-search count=2
2025/04/25 07:27:43 INFO Tools loaded server=fetch count=1
2025/04/25 07:27:43 INFO Tools loaded server=mcp-restaurant-order count=2

  You: What does MCP stand for? using brave-serch.
2025/04/25 07:27:46 INFO 🔧 Using tool name=server-brave-search__brave_web_search

  Assistant:


  The search results for MCP include:

  • Male Chauvinist Pig
  • Medicaid Managed Care Plan
  • Model Context Protocol
  • Microsoft Certified Professional
  • Macintosh Coprocessor Platform
  • Burroughs MCP, a Unisys/Burroughs computer operating syste
```
