### PR TITLE
feat: add env support in mcp server config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,12 +11,13 @@ import (
 
 // MCPServerConfig represents configuration for an MCP server
 type MCPServerConfig struct {
-	Command       string   `json:"command,omitempty"`
-	Args          []string `json:"args,omitempty"`
-	URL           string   `json:"url,omitempty"`
-	Headers       []string `json:"headers,omitempty"`
-	AllowedTools  []string `json:"allowedTools,omitempty"`
-	ExcludedTools []string `json:"excludedTools,omitempty"`
+	Command       string         `json:"command,omitempty"`
+	Args          []string       `json:"args,omitempty"`
+	Env           map[string]any `json:"env,omitempty"`
+	URL           string         `json:"url,omitempty"`
+	Headers       []string       `json:"headers,omitempty"`
+	AllowedTools  []string       `json:"allowedTools,omitempty"`
+	ExcludedTools []string       `json:"excludedTools,omitempty"`
 }
 
 // Config represents the application configuration

--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -194,7 +194,12 @@ func (m *MCPToolManager) shouldExcludeTool(toolName string, serverConfig config.
 func (m *MCPToolManager) createMCPClient(ctx context.Context, serverName string, serverConfig config.MCPServerConfig) (client.MCPClient, error) {
 	if serverConfig.Command != "" {
 		// STDIO client
-		return client.NewStdioMCPClient(serverConfig.Command, nil, serverConfig.Args...)
+		env := make([]string, 0, len(serverConfig.Env))
+		for k, v := range serverConfig.Env {
+			env = append(env, fmt.Sprintf("%s=%v", k, v))
+		}
+
+		return client.NewStdioMCPClient(serverConfig.Command, env, serverConfig.Args...)
 	} else if serverConfig.URL != "" {
 		// SSE client
 		sseClient, err := client.NewSSEMCPClient(serverConfig.URL)


### PR DESCRIPTION
After a major code refactor, I noticed that `env in McpServerConfig` was no longer working, 
so I’ve updated the code to fix this.

If the exclusion of env was intentional, please feel free to close this PR. Thank you for your time.