### PR TITLE
Fix object schema missing properties error for tools without input parameters

### DIFF
--- a/internal/tools/mcp.go
+++ b/internal/tools/mcp.go
@@ -121,6 +121,13 @@ func (m *MCPToolManager) loadServerTools(ctx context.Context, serverName string,
 			return fmt.Errorf("conv mcp tool input schema fail(unmarshal): %w, tool name: %s", err, mcpTool.Name)
 		}
 
+		// Fix for issue #89: Ensure object schemas have a properties field
+		// OpenAI function calling requires object schemas to have a "properties" field
+		// even if it's empty, otherwise it throws "object schema missing properties" error
+		if inputSchema.Type == "object" && inputSchema.Properties == nil {
+			inputSchema.Properties = make(openapi3.Schemas)
+		}
+
 		// Create prefixed tool name
 		prefixedName := fmt.Sprintf("%s__%s", serverName, mcpTool.Name)
 


### PR DESCRIPTION
## Summary
Fixes #89: Tools created without input properties were causing OpenAI function calling validation errors.

## Problem
When MCP tools were created without input parameters using `mcp.NewTool("foo", mcp.WithDescription("tool without input"))`, the resulting OpenAPI schema had `Type="object"` but `Properties=nil`. This violated OpenAI's function calling schema requirements, causing the error:

```
OpenAIException - Invalid schema for function 'bar__foo' In context=(), object schema missing properties
```

## Solution
- Added schema validation fix in `loadServerTools` to ensure object schemas have an empty properties map when `Properties` is `nil`
- The fix is minimal and targeted: `if inputSchema.Type == "object" && inputSchema.Properties == nil { inputSchema.Properties = make(openapi3.Schemas) }`

## Testing
- Added comprehensive regression test `TestIssue89_ObjectSchemaMissingProperties`
- Added additional test coverage for tools without properties
- All existing tests continue to pass
- Project builds successfully with no linting issues

## Impact
- ✅ Resolves OpenAI function calling validation errors for tools without input parameters
- ✅ Maintains backward compatibility
- ✅ Users no longer need the workaround of adding dummy `__unused__` parameters
- ✅ No breaking changes to existing functionality

🤖 Generated with [opencode](https://opencode.ai)