### PR TITLE
Refactor: Extract shared code between normal and script modes (Issue #92)

### DIFF
--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcphost/internal/config"
+	"github.com/mark3labs/mcphost/internal/models"
+)
+
+// SpinnerFunc is a function type for showing spinners during agent creation
+type SpinnerFunc func(message string, fn func() error) error
+
+// AgentCreationOptions contains options for creating an agent
+type AgentCreationOptions struct {
+	ModelConfig      *models.ProviderConfig
+	MCPConfig        *config.Config
+	SystemPrompt     string
+	MaxSteps         int
+	StreamingEnabled bool
+	ShowSpinner      bool        // For Ollama models
+	Quiet            bool        // Skip spinner if quiet
+	SpinnerFunc      SpinnerFunc // Function to show spinner (provided by caller)
+}
+
+// CreateAgent creates an agent with optional spinner for Ollama models
+func CreateAgent(ctx context.Context, opts *AgentCreationOptions) (*Agent, error) {
+	agentConfig := &AgentConfig{
+		ModelConfig:      opts.ModelConfig,
+		MCPConfig:        opts.MCPConfig,
+		SystemPrompt:     opts.SystemPrompt,
+		MaxSteps:         opts.MaxSteps,
+		StreamingEnabled: opts.StreamingEnabled,
+	}
+
+	var agent *Agent
+	var err error
+
+	// Show spinner for Ollama models if requested and not quiet
+	if opts.ShowSpinner && strings.HasPrefix(opts.ModelConfig.ModelString, "ollama:") && !opts.Quiet && opts.SpinnerFunc != nil {
+		err = opts.SpinnerFunc("Loading Ollama model...", func() error {
+			agent, err = NewAgent(ctx, agentConfig)
+			return err
+		})
+	} else {
+		agent, err = NewAgent(ctx, agentConfig)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create agent: %v", err)
+	}
+
+	return agent, nil
+}
+
+// ParseModelName extracts provider and model name from model string
+func ParseModelName(modelString string) (provider, model string) {
+	parts := strings.SplitN(modelString, ":", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "unknown", "unknown"
+}

--- a/internal/config/merger.go
+++ b/internal/config/merger.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+// MergeConfigs merges script frontmatter config with base config
+func MergeConfigs(baseConfig *Config, scriptConfig *Config) *Config {
+	merged := *baseConfig // Copy base config
+
+	// Override MCP servers if script provides them
+	if len(scriptConfig.MCPServers) > 0 {
+		merged.MCPServers = scriptConfig.MCPServers
+	}
+
+	// Add other merge logic as needed for future config fields
+	return &merged
+}
+
+// LoadAndValidateConfig loads config from viper and validates it
+func LoadAndValidateConfig() (*Config, error) {
+	config := &Config{
+		MCPServers: make(map[string]MCPServerConfig),
+	}
+	if err := viper.Unmarshal(config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %v", err)
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %v", err)
+	}
+
+	return config, nil
+}

--- a/internal/ui/factory.go
+++ b/internal/ui/factory.go
@@ -1,0 +1,93 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcphost/internal/auth"
+	"github.com/mark3labs/mcphost/internal/models"
+)
+
+// AgentInterface defines the interface we need from agent to avoid import cycles
+type AgentInterface interface {
+	GetLoadingMessage() string
+	GetTools() []any                // Using any to avoid importing tool types
+	GetLoadedServerNames() []string // Add this method for debug config
+}
+
+// CLISetupOptions contains options for setting up CLI
+type CLISetupOptions struct {
+	Agent          AgentInterface
+	ModelString    string
+	Debug          bool
+	Compact        bool
+	Quiet          bool
+	ShowDebug      bool   // Whether to show debug config
+	ProviderAPIKey string // For OAuth detection
+}
+
+// parseModelName extracts provider and model name from model string
+func parseModelName(modelString string) (provider, model string) {
+	parts := strings.SplitN(modelString, ":", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "unknown", "unknown"
+}
+
+// SetupCLI creates and configures CLI with standard info display
+func SetupCLI(opts *CLISetupOptions) (*CLI, error) {
+	if opts.Quiet {
+		return nil, nil // No CLI in quiet mode
+	}
+
+	cli, err := NewCLI(opts.Debug, opts.Compact)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CLI: %v", err)
+	}
+
+	// Parse model string for display and usage tracking
+	provider, model := parseModelName(opts.ModelString)
+
+	// Set the model name for consistent display
+	if model != "unknown" {
+		cli.SetModelName(model)
+	}
+
+	// Set up usage tracking for supported providers
+	if provider != "unknown" && model != "unknown" {
+		// Skip usage tracking for ollama as it's not in models.dev
+		if provider != "ollama" {
+			registry := models.GetGlobalRegistry()
+			if modelInfo, err := registry.ValidateModel(provider, model); err == nil {
+				// Check if OAuth credentials are being used for Anthropic models
+				isOAuth := false
+				if provider == "anthropic" {
+					_, source, err := auth.GetAnthropicAPIKey(opts.ProviderAPIKey)
+					if err == nil && strings.HasPrefix(source, "stored OAuth") {
+						isOAuth = true
+					}
+				}
+
+				usageTracker := NewUsageTracker(modelInfo, provider, 80, isOAuth) // Will be updated with actual width
+				cli.SetUsageTracker(usageTracker)
+			}
+		}
+	}
+
+	// Display model info
+	if provider != "unknown" && model != "unknown" {
+		cli.DisplayInfo(fmt.Sprintf("Model loaded: %s (%s)", provider, model))
+	}
+
+	// Display loading message if available (e.g., GPU fallback info)
+	if loadingMessage := opts.Agent.GetLoadingMessage(); loadingMessage != "" {
+		cli.DisplayInfo(loadingMessage)
+	}
+
+	// Display tool count
+	tools := opts.Agent.GetTools()
+	cli.DisplayInfo(fmt.Sprintf("Loaded %d tools from MCP servers", len(tools)))
+
+	return cli, nil
+}


### PR DESCRIPTION
## Summary

This PR addresses issue #92 by extracting significant code duplication between normal mode (`cmd/root.go`) and script mode (`cmd/script.go`) into reusable factory functions and utilities.

### Key Changes

- **Agent Creation Factory** (`internal/agent/factory.go`): Centralized agent creation with configurable spinner support
- **UI Setup Factory** (`internal/ui/factory.go`): Standardized CLI initialization with usage tracking and model info display  
- **Config Merger** (`internal/config/merger.go`): Unified config loading and script frontmatter merging
- **Refactored Command Files**: Both `cmd/root.go` and `cmd/script.go` now use shared factories

### Benefits

- **Reduced ~33 lines of duplicated code** across the two command files
- **Single source of truth** for agent creation and CLI setup logic
- **Consistent behavior** between normal and script modes
- **Easier maintenance** - changes automatically apply to both modes
- **Better testability** - factory functions can be unit tested independently
- **Cleaner command files** - focus on mode-specific logic only

### Code Quality

- All existing tests pass ✅
- Build verification successful ✅  
- Code formatting and linting checks passed ✅
- Both normal and script modes tested for basic functionality ✅

### Files Modified

- `cmd/root.go` - Refactored to use new factories
- `cmd/script.go` - Refactored to use new factories
- `internal/agent/factory.go` - **New** agent creation factory
- `internal/ui/factory.go` - **New** CLI setup factory
- `internal/config/merger.go` - **New** config loading utilities

This refactoring maintains full backward compatibility while significantly improving code organization and maintainability.

## Test plan

- [x] All existing tests pass
- [x] Build verification successful
- [x] Normal mode functionality verified
- [x] Script mode functionality verified
- [x] Code formatting and linting checks passed

🤖 Generated with [opencode](https://opencode.ai)