### PR TITLE
Less terminal flickering during response streaming

### DIFF
--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -30,6 +30,7 @@ type UIMessage struct {
 	Height    int
 	Content   string
 	Timestamp time.Time
+	Streaming bool
 }
 
 // Helper functions to get theme colors
@@ -563,6 +564,7 @@ func (c *MessageContainer) UpdateLastMessage(content string) {
 			renderer := NewMessageRenderer(c.width, false)
 			newMsg = renderer.RenderAssistantMessage(content, lastMsg.Timestamp, c.modelName)
 		}
+		newMsg.Streaming = lastMsg.Streaming // Preserve streaming state
 		c.messages[lastIdx] = newMsg
 	}
 }
@@ -608,12 +610,16 @@ func (c *MessageContainer) Render() string {
 		}
 	}
 
-	return lipgloss.NewStyle().
-		Width(c.width).
-		PaddingBottom(1).
-		Render(
-			lipgloss.JoinVertical(lipgloss.Top, parts...),
-		)
+	style := lipgloss.NewStyle().
+		Width(c.width)
+
+	if !c.compactMode {
+		style = style.PaddingBottom(1)
+	}
+
+	return style.Render(
+		lipgloss.JoinVertical(lipgloss.Top, parts...),
+	)
 }
 
 // renderEmptyState renders an enhanced initial empty state
@@ -695,7 +701,7 @@ func (c *MessageContainer) renderCompactMessages() string {
 		lines = append(lines, msg.Content)
 	}
 
-	return strings.Join(lines, "\n") + "\n"
+	return strings.Join(lines, "\n")
 }
 
 // renderCompactEmptyState renders a simple empty state for compact mode

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -64,7 +64,7 @@ func (m spinnerModel) View() string {
 		Foreground(theme.Text).
 		Italic(true)
 
-	return fmt.Sprintf("  %s %s",
+	return fmt.Sprintf(" %s %s",
 		spinnerStyle.Render(m.spinner.View()),
 		messageStyle.Render(m.message))
 }


### PR DESCRIPTION
Attempting to resolve https://github.com/mark3labs/mcphost/issues/96

After leaving a few comments on the issue (https://github.com/mark3labs/mcphost/issues/96#issuecomment-3033704265 + https://github.com/mark3labs/mcphost/issues/96#issuecomment-3046631671) I figured I should probably give it a shot.  I haven't tested all the edge cases as I'm new to using mcphost, but so far I've got it working for compact mode.

I'll note that the more correct way to do this would be to let the bubbletea framework do more of the heavy lifting, but I can't really think of a "low impact" way of adding that logic.  So, I'm just hacking something in for now.  If the maintainer wants me to take a bigger bite out of this code, I'd be happy to try and do a larger refactor.

Either way, I'm happy to keep tinkering with this in my spare time, or I'd be happy if someone else takes this across the finish line, either way :shrug:

Currently working commands:
* `mcphost --compact`
* `mcphost --compact --prompt="say hello succinctly"`
* `mcphost --compact --prompt="say hello succinctly" --no-exit`
* `mcphost --debug --compact`
* `mcphost --debug --compact --prompt="say hello succinctly"`
* `mcphost --debug --compact --prompt="say hello succinctly" --no-exit`