### PR TITLE
Sanitize tool arguments to handle empty or malformed input

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
-	"time"
-
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cloudwego/eino/components/model"
 	"github.com/cloudwego/eino/components/tool"
@@ -15,6 +12,8 @@ import (
 	"github.com/mark3labs/mcphost/internal/config"
 	"github.com/mark3labs/mcphost/internal/models"
 	"github.com/mark3labs/mcphost/internal/tools"
+	"strings"
+	"time"
 )
 
 // AgentConfig is the config for agent.
@@ -183,7 +182,13 @@ func (a *Agent) GenerateWithLoopAndStreaming(ctx context.Context, messages []*sc
 						onToolExecution(toolCall.Function.Name, true)
 					}
 
-					output, err := selectedTool.(tool.InvokableTool).InvokableRun(ctx, toolCall.Function.Arguments)
+					// Sanitize arguments for common LLM junk like "}{"
+					arguments := toolCall.Function.Arguments
+					if len(arguments) > 0 && strings.Trim(arguments, " \t\n\r{}") == "" {
+						arguments = "{}"
+					}
+
+					output, err := selectedTool.(tool.InvokableTool).InvokableRun(ctx, arguments)
 
 					// Notify tool execution end
 					if onToolExecution != nil {


### PR DESCRIPTION
A lot of LLM tools have issues providing a clean input especially when a tool does not require parameters. Malformed `}{` or `}{}{}{` or other are seen with qwen3, llama3.1, mistral, cogito. This input sanitizer fixes it and gives much better results.