### PR TITLE
feat: add --tls-skip-verify flag for self-signed certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ export GOOGLE_API_KEY='your-api-key'
 - Get your API server base URL, API key and model name
 - Use `--provider-url` and `--provider-api-key` flags or set environment variables
 
+5. Self-Signed Certificates (TLS):
+If your provider uses self-signed certificates (e.g., local Ollama with HTTPS), you can skip certificate verification:
+```bash
+mcphost --provider-url https://192.168.1.100:443 --tls-skip-verify
+```
+⚠️ **WARNING**: Only use `--tls-skip-verify` for development or when connecting to trusted servers with self-signed certificates. This disables TLS certificate verification and is insecure for production use.
+
 ## Installation 📦
 
 ```bash
@@ -741,6 +748,7 @@ mcphost -p "Generate a random UUID" --quiet | tr '[:lower:]' '[:upper:]'
 ### Flags
 - `--provider-url string`: Base URL for the provider API (applies to OpenAI, Anthropic, Ollama, and Google)
 - `--provider-api-key string`: API key for the provider (applies to OpenAI, Anthropic, and Google)
+- `--tls-skip-verify`: Skip TLS certificate verification (WARNING: insecure, use only for self-signed certificates)
 - `--config string`: Config file location (default is $HOME/.mcphost.yml)
 - `--system-prompt string`: system-prompt file location
 - `--debug`: Enable debug logging
@@ -808,6 +816,7 @@ stream: false  # Disable streaming (default: true)
 # API Configuration
 provider-api-key: "your-api-key"      # For OpenAI, Anthropic, or Google
 provider-url: "https://api.openai.com/v1"  # Custom base URL
+tls-skip-verify: false  # Skip TLS certificate verification (default: false)
 ```
 
 **Note**: Command-line flags take precedence over config file values.

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -134,6 +134,9 @@ func overrideConfigWithFrontmatter(scriptFile string, variables map[string]strin
 	if scriptConfig.Stream != nil && !flagChanged("stream") {
 		viper.Set("stream", *scriptConfig.Stream)
 	}
+	if scriptConfig.TLSSkipVerify && !flagChanged("tls-skip-verify") {
+		viper.Set("tls-skip-verify", scriptConfig.TLSSkipVerify)
+	}
 }
 
 // parseCustomVariables extracts custom variables from command line arguments
@@ -392,6 +395,9 @@ func parseScriptContent(content string, variables map[string]string) (*config.Co
 		if noExit := frontmatterViper.GetBool("no-exit"); noExit {
 			scriptConfig.NoExit = noExit
 		}
+		if tlsSkipVerify := frontmatterViper.GetBool("tls-skip-verify"); tlsSkipVerify {
+			scriptConfig.TLSSkipVerify = tlsSkipVerify
+		}
 	}
 
 	// Set prompt from content after frontmatter
@@ -586,6 +592,7 @@ func runScriptMode(ctx context.Context, mcpConfig *config.Config, prompt string,
 		TopP:           &finalTopP,
 		TopK:           &finalTopK,
 		StopSequences:  finalStopSequences,
+		TLSSkipVerify:  viper.GetBool("tls-skip-verify"),
 	}
 
 	// Create the agent using the factory (scripts don't need spinners)

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -28,6 +28,28 @@ mcphost script default-values-demo.sh \
   --args:format "json"
 ```
 
+### `tls-test-script.sh`
+Demonstrates TLS skip verify for connecting to providers with self-signed certificates.
+
+**Features showcased:**
+- `tls-skip-verify` configuration in script frontmatter
+- Connecting to HTTPS endpoints with self-signed certificates
+- Security considerations for development environments
+
+**Usage:**
+```bash
+# Run with TLS skip verify enabled (configured in script)
+mcphost script tls-test-script.sh
+
+# Override the provider URL
+mcphost script tls-test-script.sh --provider-url https://192.168.1.100:443
+
+# Disable TLS skip verify via command line (overrides script config)
+mcphost script tls-test-script.sh --tls-skip-verify=false
+```
+
+⚠️ **WARNING**: Only use `tls-skip-verify` for development or when connecting to trusted servers with self-signed certificates.
+
 ## Variable Syntax Reference
 
 MCPHost scripts support two types of variables:

--- a/examples/scripts/tls-test-script.sh
+++ b/examples/scripts/tls-test-script.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S mcphost script
+---
+# Example script demonstrating TLS skip verify for self-signed certificates
+model: "ollama:llama3.2"
+provider-url: "https://localhost:8443"
+tls-skip-verify: true
+max-tokens: 1000
+---
+Hello! Can you tell me about TLS certificates and why someone might need to skip certificate verification in development environments?

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,6 +117,9 @@ type Config struct {
 	TopP          *float32 `json:"top-p,omitempty" yaml:"top-p,omitempty"`
 	TopK          *int32   `json:"top-k,omitempty" yaml:"top-k,omitempty"`
 	StopSequences []string `json:"stop-sequences,omitempty" yaml:"stop-sequences,omitempty"`
+
+	// TLS configuration
+	TLSSkipVerify bool `json:"tls-skip-verify,omitempty" yaml:"tls-skip-verify,omitempty"`
 }
 
 // GetTransportType returns the transport type for the server config

--- a/internal/models/providers_test.go
+++ b/internal/models/providers_test.go
@@ -1,0 +1,123 @@
+package models
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestCreateHTTPClientWithTLSConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		skipVerify   bool
+		wantInsecure bool
+	}{
+		{
+			name:         "skip verify disabled",
+			skipVerify:   false,
+			wantInsecure: false,
+		},
+		{
+			name:         "skip verify enabled",
+			skipVerify:   true,
+			wantInsecure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := createHTTPClientWithTLSConfig(tt.skipVerify)
+
+			if client == nil {
+				t.Fatal("expected non-nil client")
+			}
+
+			// Check if the client has a custom transport when skipVerify is true
+			if tt.skipVerify {
+				transport, ok := client.Transport.(*http.Transport)
+				if !ok {
+					t.Fatal("expected *http.Transport when skipVerify is true")
+				}
+
+				if transport.TLSClientConfig == nil {
+					t.Fatal("expected non-nil TLSClientConfig when skipVerify is true")
+				}
+
+				if transport.TLSClientConfig.InsecureSkipVerify != tt.wantInsecure {
+					t.Errorf("InsecureSkipVerify = %v, want %v",
+						transport.TLSClientConfig.InsecureSkipVerify, tt.wantInsecure)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateOAuthHTTPClient(t *testing.T) {
+	tests := []struct {
+		name         string
+		accessToken  string
+		skipVerify   bool
+		wantInsecure bool
+	}{
+		{
+			name:         "oauth with skip verify disabled",
+			accessToken:  "test-token",
+			skipVerify:   false,
+			wantInsecure: false,
+		},
+		{
+			name:         "oauth with skip verify enabled",
+			accessToken:  "test-token",
+			skipVerify:   true,
+			wantInsecure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := createOAuthHTTPClient(tt.accessToken, tt.skipVerify)
+
+			if client == nil {
+				t.Fatal("expected non-nil client")
+			}
+
+			// Check that the transport is an oauthTransport
+			oauthTransport, ok := client.Transport.(*oauthTransport)
+			if !ok {
+				t.Fatal("expected *oauthTransport")
+			}
+
+			if oauthTransport.accessToken != tt.accessToken {
+				t.Errorf("accessToken = %v, want %v", oauthTransport.accessToken, tt.accessToken)
+			}
+
+			// Check the base transport when skipVerify is true
+			if tt.skipVerify {
+				baseTransport, ok := oauthTransport.base.(*http.Transport)
+				if !ok {
+					t.Fatal("expected base transport to be *http.Transport when skipVerify is true")
+				}
+
+				if baseTransport.TLSClientConfig == nil {
+					t.Fatal("expected non-nil TLSClientConfig when skipVerify is true")
+				}
+
+				if baseTransport.TLSClientConfig.InsecureSkipVerify != tt.wantInsecure {
+					t.Errorf("InsecureSkipVerify = %v, want %v",
+						baseTransport.TLSClientConfig.InsecureSkipVerify, tt.wantInsecure)
+				}
+			}
+		})
+	}
+}
+
+func TestProviderConfigTLSSkipVerify(t *testing.T) {
+	// Test that ProviderConfig properly stores TLSSkipVerify
+	config := &ProviderConfig{
+		ModelString:   "test:model",
+		TLSSkipVerify: true,
+	}
+
+	if !config.TLSSkipVerify {
+		t.Error("expected TLSSkipVerify to be true")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--tls-skip-verify` flag to allow connections to providers with self-signed certificates
- Implements TLS skip verify support for all providers that accept custom URLs (Ollama, OpenAI, Anthropic, Google, Azure)
- Includes comprehensive tests and documentation with security warnings

## Motivation
This PR addresses #113 where users need to connect to Ollama instances secured with self-signed certificates. The current implementation fails with certificate validation errors when trying to connect to HTTPS endpoints with self-signed certificates.

## Changes
1. **New Flag**: Added `--tls-skip-verify` command-line flag with appropriate security warnings
2. **Provider Updates**: Modified all provider implementations to support TLS skip verify:
   - Ollama
   - OpenAI (and OpenAI-compatible endpoints)
   - Anthropic (both API key and OAuth modes)
   - Google/Gemini
   - Azure OpenAI
3. **Helper Functions**: Created `createHTTPClientWithTLSConfig()` for consistent TLS configuration
4. **Tests**: Added unit tests to verify TLS skip verify functionality
5. **Documentation**: Updated README with usage examples and clear security warnings

## Security Considerations
⚠️ **WARNING**: The `--tls-skip-verify` flag disables TLS certificate verification and should only be used:
- In development environments
- When connecting to trusted servers with self-signed certificates
- Never in production environments

The implementation maintains secure defaults - TLS verification is only skipped when explicitly requested by the user.

## Testing
```bash
# Run the new tests
go test -race ./internal/models -run "TestCreateHTTPClientWithTLSConfig|TestCreateOAuthHTTPClient|TestProviderConfigTLSSkipVerify"
```

All tests pass successfully.

## Example Usage
```bash
# Connect to Ollama with self-signed certificate
mcphost --provider-url https://192.168.1.100:443 --tls-skip-verify -m ollama:llama3.2

# Use with config file
# In ~/.mcphost.yml:
provider-url: "https://localhost:8443"
tls-skip-verify: true
```

Fixes #113

🤖 Generated with [opencode](https://opencode.ai)