### PR TITLE
Session flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -567,6 +567,13 @@ func runNormalMode(ctx context.Context) error {
 	var messages []*schema.Message
 	var sessionManager *session.Manager
 	if sessionPath != "" {
+		_, err := os.Stat(sessionPath)
+		if os.IsNotExist(err) {
+			content := []byte("{}")
+			if err := os.WriteFile(sessionPath, content, 0664); err != nil {
+				panic(err)
+			}
+		}
 		loadSessionPath = sessionPath
 		saveSessionPath = sessionPath
 	}


### PR DESCRIPTION
add a convenience `session` flag for both loading and saving. `mcphost --session session.json` is equivalent to `mcphost --load-session session.json --save-session session.json`