### PR TITLE
Feat: Add option to require approval before tool execution

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,6 +166,7 @@ type Config struct {
 	Stream         *bool                      `json:"stream,omitempty" yaml:"stream,omitempty"`
 	Theme          any                        `json:"theme" yaml:"theme"`
 	MarkdownTheme  any                        `json:"markdown-theme" yaml:"markdown-theme"`
+	ApproveToolRun bool                       `json:"approve-tool-run" yaml:"approve-tool-run"`
 
 	// Model generation parameters
 	MaxTokens     int      `json:"max-tokens,omitempty" yaml:"max-tokens,omitempty"`

--- a/internal/ui/cli.go
+++ b/internal/ui/cli.go
@@ -13,9 +13,7 @@ import (
 	"golang.org/x/term"
 )
 
-var (
-	promptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
-)
+var promptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
 
 // CLI manages the command-line interface for MCPHost, providing message rendering,
 // user input handling, and display management. It supports both standard and compact
@@ -375,6 +373,22 @@ func (c *CLI) DisplayServers(servers []string) {
 // like "/help", "/tools", etc.
 func (c *CLI) IsSlashCommand(input string) bool {
 	return strings.HasPrefix(input, "/")
+}
+
+// GetToolApproval asks the user for permission to execute the tool with the given
+// arguments. Returns true if the user approves.
+func (c *CLI) GetToolApproval(toolName, toolArgs string) (bool, error) {
+	input := NewToolApprovalInput(toolName, toolArgs, c.width)
+	p := tea.NewProgram(input)
+	finalModel, err := p.Run()
+	if err != nil {
+		return false, err
+	}
+
+	if finalInput, ok := finalModel.(*ToolApprovalInput); ok {
+		return finalInput.approved, nil
+	}
+	return false, fmt.Errorf("GetToolApproval: unexpected error type")
 }
 
 // SlashCommandResult encapsulates the outcome of processing a slash command,

--- a/internal/ui/tool_approval_input.go
+++ b/internal/ui/tool_approval_input.go
@@ -1,0 +1,135 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type ToolApprovalInput struct {
+	textarea textarea.Model
+	toolName string
+	toolArgs string
+	width    int
+	selected bool // true when "yes" is highlighted and false when "no" is
+	approved bool
+	done     bool
+}
+
+func NewToolApprovalInput(toolName, toolArgs string, width int) *ToolApprovalInput {
+	ta := textarea.New()
+	ta.Placeholder = ""
+	ta.ShowLineNumbers = false
+	ta.CharLimit = 1000
+	ta.SetWidth(width - 8) // Account for container padding, border and internal padding
+	ta.SetHeight(4)        // Default to 3 lines like huh
+	ta.Focus()
+
+	// Style the textarea to match huh theme
+	ta.FocusedStyle.Base = lipgloss.NewStyle()
+	ta.FocusedStyle.Placeholder = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	ta.FocusedStyle.Text = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	ta.FocusedStyle.Prompt = lipgloss.NewStyle()
+	ta.FocusedStyle.CursorLine = lipgloss.NewStyle()
+	ta.Cursor.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
+
+	return &ToolApprovalInput{
+		textarea: ta,
+		toolName: toolName,
+		toolArgs: toolArgs,
+		width:    width,
+		selected: true,
+	}
+}
+
+func (t *ToolApprovalInput) Init() tea.Cmd {
+	return textarea.Blink
+}
+
+func (t *ToolApprovalInput) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "y", "Y":
+			t.approved = true
+			t.done = true
+			return t, tea.Quit
+		case "n", "N":
+			t.approved = false
+			t.done = true
+			return t, tea.Quit
+		case "left":
+			t.selected = true
+			return t, nil
+		case "right":
+			t.selected = false
+			return t, nil
+		case "enter":
+			t.approved = t.selected
+			t.done = true
+			return t, tea.Quit
+		case "esc", "ctrl+c":
+			t.approved = false
+			t.done = true
+			return t, tea.Quit
+		}
+	}
+	return t, nil
+}
+
+func (t *ToolApprovalInput) View() string {
+	if t.done {
+		return "we are done"
+	}
+	// Add left padding to entire component (2 spaces like other UI elements)
+	containerStyle := lipgloss.NewStyle().PaddingLeft(2)
+
+	// Title
+	titleStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("252")).
+		MarginBottom(1)
+
+	// Input box with huh-like styling
+	inputBoxStyle := lipgloss.NewStyle().
+		Border(lipgloss.ThickBorder()).
+		BorderLeft(true).
+		BorderRight(false).
+		BorderTop(false).
+		BorderBottom(false).
+		BorderForeground(lipgloss.Color("39")).
+		PaddingLeft(1).
+		Width(t.width - 2) // Account for container padding
+
+	// Style for the currently selected/highlighted option
+	selectedStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("42")). // Bright green
+		Bold(true).
+		Underline(true)
+
+	// Style for the unselected/unhighlighted option
+	unselectedStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")) // Dark gray
+
+	// Build the view
+	var view strings.Builder
+	view.WriteString(titleStyle.Render("Allow tool execution"))
+	view.WriteString("\n")
+	details := fmt.Sprintf("Tool: %s\nArguments: %s\n\n", t.toolName, t.toolArgs)
+	view.WriteString(details)
+	view.WriteString("Allow tool execution: ")
+
+	var yesText, noText string
+	if t.selected {
+		yesText = selectedStyle.Render("[y]es")
+		noText = unselectedStyle.Render("[n]o")
+	} else {
+		yesText = unselectedStyle.Render("[y]es")
+		noText = selectedStyle.Render("[n]o")
+	}
+	view.WriteString(yesText + "/" + noText + "\n")
+
+	return containerStyle.Render(inputBoxStyle.Render(view.String()))
+}

--- a/sdk/mcphost.go
+++ b/sdk/mcphost.go
@@ -142,6 +142,7 @@ func (m *MCPHost) Prompt(ctx context.Context, message string) (string, error) {
 		nil, // onToolResult
 		nil, // onResponse
 		nil, // onToolCallContent
+		nil, // onToolApproval
 	)
 	if err != nil {
 		return "", err
@@ -181,6 +182,7 @@ func (m *MCPHost) PromptWithCallbacks(
 		nil, // onResponse
 		nil, // onToolCallContent
 		onStreaming,
+		nil, // onToolApproval
 	)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Adds a new CLI option, `--approve-tool-run` (or via config setting), that when enabled, prompts the user to approve a tool's execution before it runs.

This option is disabled by default to maintain existing behavior.