### PR TITLE
Add AgentRank score badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCPHost 🤖
 
+[![AgentRank](https://agentrank-ai.com/api/badge/tool/mark3labs--mcphost)](https://agentrank-ai.com/tool/mark3labs--mcphost/)
+
 A CLI host application that enables Large Language Models (LLMs) to interact with external tools through the Model Context Protocol (MCP). Currently supports Claude, OpenAI, Google Gemini, and Ollama models.
 
 Discuss the Project on [Discord](https://discord.gg/RqSS2NQVsY)


### PR DESCRIPTION
Hi! Your tool ranks in the top 20 on [AgentRank](https://agentrank-ai.com/tool/mark3labs--mcphost/), a ranked index of MCP servers and agent tools scored daily from real GitHub signals. **mcphost** currently scores **64.89/100**.

This PR adds a score badge to your README so visitors can see how the tool stacks up in the ecosystem:

[![AgentRank](https://agentrank-ai.com/api/badge/tool/mark3labs--mcphost)](https://agentrank-ai.com/tool/mark3labs--mcphost/)

Happy to adjust placement. No pressure to merge — just wanted to let you know you're ranking well.